### PR TITLE
Pr cr devel

### DIFF
--- a/1_launcher/launch_velodyne.sh
+++ b/1_launcher/launch_velodyne.sh
@@ -4,7 +4,7 @@
 #  $(echo "exec ros2 launch velodyne velodyne-all-nodes-VLP16-launch.py")
 
 # Change publish rate 0.1s -> 0.05s (Default rpm: 600.0)
-sed -i "s/^\s*rpm:\s*[0-9.]\+/        rpm: 1200.0/" /opt/ros/humble/share/velodyne_driver/config/VLP16-velodyne_driver_node-params.yaml
+sed -i "s/^\s*rpm:\s*[0-9.]\+/        rpm: 1200.0/" /root/ros2_ws/src/velodyne/velodyne_driver/config/VLP16-velodyne_driver_node-params.yaml
 
 # https://qiita.com/miriwo/items/e829f5a78314e0878f1b
 case $1 in

--- a/1_launcher/launch_velodyne.sh
+++ b/1_launcher/launch_velodyne.sh
@@ -3,9 +3,6 @@
 # https://qiita.com/porizou1/items/c815cb17749aad561909
 #  $(echo "exec ros2 launch velodyne velodyne-all-nodes-VLP16-launch.py")
 
-# Change publish rate 0.1s -> 0.05s (Default rpm: 600.0)
-sed -i "s/^\s*rpm:\s*[0-9.]\+/        rpm: 1200.0/" /root/ros2_ws/src/velodyne/velodyne_driver/config/VLP16-velodyne_driver_node-params.yaml
-
 # https://qiita.com/miriwo/items/e829f5a78314e0878f1b
 case $1 in
 "run")

--- a/2_ros_packages/whill_driver/README.md
+++ b/2_ros_packages/whill_driver/README.md
@@ -34,8 +34,8 @@ WHILL model CR の電源制御指令
 * float64 y : 左ホイール角度($ \pm\pi $) [rad]
 * float64 z : None
 ### `~/motor_speed` ([geometry_msgs/Vector3.msg](https://docs.ros2.org/latest/api/geometry_msgs/msg/Vector3.html))
-* float64 x : 右ホイール速度 [m/s]
-* float64 y : 左ホイール速度 [m/s]
+* float64 x : 右ホイール速度 [km/h]
+* float64 y : 左ホイール速度 [km/h]
 * float64 z : None
 ### `~/speed_mode` ([std_msgs/Int16.msg](http://docs.ros.org/en/noetic/api/std_msgs/html/msg/Int16.html))
 *  int16 data : スピードモード

--- a/3_dockerfiles_exp/dockerfile.velodyne
+++ b/3_dockerfiles_exp/dockerfile.velodyne
@@ -11,6 +11,7 @@ RUN source /opt/ros/${ROS_DISTRO}/setup.bash \
 && mkdir -p ~/ros2_ws/src\
 &&  cd ~/ros2_ws/src \
 && git clone --depth 1 https://github.com/ros-drivers/velodyne.git \
+&& sed -i "s/^\s*rpm:\s*[0-9.]\+/        rpm: 1200.0/" ~/ros2_ws/src/velodyne/velodyne_driver/config/VLP16-velodyne_driver_node-params.yaml && \
 && . /opt/ros/${ROS_DISTRO}/setup.sh \
 && cd ~/ros2_ws/ \
 && colcon build \

--- a/project_launch_exp.sh
+++ b/project_launch_exp.sh
@@ -4,7 +4,7 @@ echo $PROJECT
 echo $ROS_DOMAIN_ID
 
 cd $ACSL_ROS2_DIR/0_host_commands/scripts/
-RMW=cyclonedds dup rtk_gnss ublox_launch rtk_gnss rtk_gnss
+RMW=cyclonedds dup rtk_gnss ublox_launch
 RMW=cyclonedds dup whill_exp
 RMW=cyclonedds dup velodyne run
 RMW=cyclonedds dup rtk_gnss run


### PR DESCRIPTION
## やったこと

* rtk_gnssのdupする部分の誤植修正
* velodyneの点群をPublishする周期を変更するためのコマンド実行場所を変更
* whillの速度指令をJoy入力から直接速度指定に変更
* whillが外部入力指令で動作中にJoy入力を検知すると，マニュアル操作に切り替わる．Joy入力が無信号となった3秒後に再度外部指令を受け付ける．

## やらないこと

* 無し

## できるようになること（ユーザ目線）

* RTKが正しく使えるようになる
* velodyne点群を0.05sで受信できるようになる
* whillが自律走行中(外部入力受信中)に，搭乗者がJoyスティックを使って割り込み操作可能になる．

## できなくなること（ユーザ目線）

* Joy入力による速度制御ではなくなるため，単に目標速度を指令するだけでは滑らかな速度追従ができなくなる．

## 動作確認

* RTKの動作が確認できた．
* 点群のPublish周期が0.05sになった．
* 直接速度指令によるwhillの速度制御が可能になった．オドメトリから速度を計算し，妥当な値となった．
* 自律走行中にJoyスティックを動かしてマニュアル走行ができた．操作を終了した3秒後に再度自律走行に切り替わった．

## Concerns and areas to focus on
