### PR TITLE
Pr cr devel

### DIFF
--- a/1_launcher/launch_velodyne.sh
+++ b/1_launcher/launch_velodyne.sh
@@ -4,7 +4,7 @@
 #  $(echo "exec ros2 launch velodyne velodyne-all-nodes-VLP16-launch.py")
 
 # Change publish rate 0.1s -> 0.05s (Default rpm: 600.0)
-sed -i "s/^\s*rpm:\s*[0-9.]\+/        rpm: 1200.0/" /opt/ros/humble/share/velodyne_driver/config/VLP16-velodyne_driver_node-params.yaml
+sed -i "s/^\s*rpm:\s*[0-9.]\+/        rpm: 1200.0/" /root/ros2_ws/src/velodyne/velodyne_driver/config/VLP16-velodyne_driver_node-params.yaml
 
 # https://qiita.com/miriwo/items/e829f5a78314e0878f1b
 case $1 in

--- a/1_launcher/launch_velodyne.sh
+++ b/1_launcher/launch_velodyne.sh
@@ -3,9 +3,6 @@
 # https://qiita.com/porizou1/items/c815cb17749aad561909
 #  $(echo "exec ros2 launch velodyne velodyne-all-nodes-VLP16-launch.py")
 
-# Change publish rate 0.1s -> 0.05s (Default rpm: 600.0)
-sed -i "s/^\s*rpm:\s*[0-9.]\+/        rpm: 1200.0/" /root/ros2_ws/src/velodyne/velodyne_driver/config/VLP16-velodyne_driver_node-params.yaml
-
 # https://qiita.com/miriwo/items/e829f5a78314e0878f1b
 case $1 in
 "run")

--- a/1_launcher/launch_velodyne.sh
+++ b/1_launcher/launch_velodyne.sh
@@ -6,12 +6,12 @@
 # https://qiita.com/miriwo/items/e829f5a78314e0878f1b
 case $1 in
 "run")
+  # Change publish rate 0.1s -> 0.05s (Default rpm: 600.0)
+  sed -i "s/^\s*rpm:\s*[0-9.]\+/        rpm: 1200.0/" /opt/ros/humble/share/velodyne_driver/config/VLP16-velodyne_driver_node-params.yaml
   $(echo "exec ros2 launch velodyne velodyne-all-nodes-VLP16-launch.py  namespace:=/${HOSTNAME}")
   #$(echo -e "ros2 run velodyne_driver velodyne_driver_node --ros-args -p device_ip:='192.168.1.201' -p model:='VLP16' -p rpm:=1200.0\n ros2 launch velodyne_pointcloud velodyne_transform_node-VLP16-launch.py" | xargs -P 2 -I @ bash -c "exec @")
   #  $(echo -e "ros2 run velodyne_driver velodyne_driver_node --ros-args -p device_ip:='192.168.1.201' -p model:='VLP16' -p rpm:=1200.0 --remap __ns:=/${HOSTNAME}\n ros2 launch velodyne_pointcloud velodyne_transform_node-VLP16-launch.py  --remap __ns:=/${HOSTNAME}" | xargs -P 2 -I @ bash -c "exec @")
   #  $(echo "exec ros2 run velodyne_driver velodyne_driver_node --ros-args -p device_ip:='192.168.1.201' -p model:='VLP16' -p rpm:=1200.0")
-  # Change publish rate 0.1s -> 0.05s (Default rpm: 600.0)
-  sed -i "s/^\s*rpm:\s*[0-9.]\+/        rpm: 1200.0/" /opt/ros/humble/share/velodyne_driver/config/VLP16-velodyne_driver_node-params.yaml
   ;;
 #ROS2のPCL2形式に変換するノードのようです。
 "convert")

--- a/1_launcher/launch_velodyne.sh
+++ b/1_launcher/launch_velodyne.sh
@@ -10,6 +10,8 @@ case $1 in
   #$(echo -e "ros2 run velodyne_driver velodyne_driver_node --ros-args -p device_ip:='192.168.1.201' -p model:='VLP16' -p rpm:=1200.0\n ros2 launch velodyne_pointcloud velodyne_transform_node-VLP16-launch.py" | xargs -P 2 -I @ bash -c "exec @")
   #  $(echo -e "ros2 run velodyne_driver velodyne_driver_node --ros-args -p device_ip:='192.168.1.201' -p model:='VLP16' -p rpm:=1200.0 --remap __ns:=/${HOSTNAME}\n ros2 launch velodyne_pointcloud velodyne_transform_node-VLP16-launch.py  --remap __ns:=/${HOSTNAME}" | xargs -P 2 -I @ bash -c "exec @")
   #  $(echo "exec ros2 run velodyne_driver velodyne_driver_node --ros-args -p device_ip:='192.168.1.201' -p model:='VLP16' -p rpm:=1200.0")
+  # Change publish rate 0.1s -> 0.05s (Default rpm: 600.0)
+  sed -i "s/^\s*rpm:\s*[0-9.]\+/        rpm: 1200.0/" /opt/ros/humble/share/velodyne_driver/config/VLP16-velodyne_driver_node-params.yaml
   ;;
 #ROS2のPCL2形式に変換するノードのようです。
 "convert")

--- a/2_ros_packages/whill_driver/README.md
+++ b/2_ros_packages/whill_driver/README.md
@@ -34,8 +34,8 @@ WHILL model CR の電源制御指令
 * float64 y : 左ホイール角度($ \pm\pi $) [rad]
 * float64 z : None
 ### `~/motor_speed` ([geometry_msgs/Vector3.msg](https://docs.ros2.org/latest/api/geometry_msgs/msg/Vector3.html))
-* float64 x : 右ホイール速度 [m/s]
-* float64 y : 左ホイール速度 [m/s]
+* float64 x : 右ホイール速度 [km/h]
+* float64 y : 左ホイール速度 [km/h]
 * float64 z : None
 ### `~/speed_mode` ([std_msgs/Int16.msg](http://docs.ros.org/en/noetic/api/std_msgs/html/msg/Int16.html))
 *  int16 data : スピードモード

--- a/2_ros_packages/whill_driver/whill_driver/main.py
+++ b/2_ros_packages/whill_driver/whill_driver/main.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-"""WHILL Chair CRの制御ROSプログラム\n
-Auther:Koki Yamaguchi \n
-year:2022 \n
+"""WHILL Chair CRの制御ROS2プログラム\n
+Auther:Koki Yamaguchi, Masanori Imoto\n
+year:2025 \n
 """
 import os
 import traceback
@@ -23,7 +23,7 @@ class whill_ope(ComWHILL):
         self.joy_x = 0.0
         self.joy_y = 0.0
         self.last_joy_time = 0.0
-        self.joy_suppression_time = 3.0  # Joy入力後に制御指令を無効化する時間
+        self.joy_suppression_time = 3.0  # Joy入力後に制御指令を無効化する時間[s]
         # データ受信のコールバック関数の定義
         self.register_callback('data_set_0', self.callback0)
         self.register_callback('data_set_1', self.callback1)
@@ -32,7 +32,7 @@ class whill_ope(ComWHILL):
 
         # 電源オン
         self.send_power_on_com(1)
-        self.start_data_stream(100)
+        self.start_data_stream(50)
         while 1:
             if self.power_status == 1:
                 break
@@ -114,7 +114,6 @@ class whill_ope(ComWHILL):
         """whillのイグニッションを管理するための関数"""
         if io:
             self.send_power_on()
-           # self.set_battery_voltage_output_mode(True)  # Model CR
         else:
             self.send_power_off()
 
@@ -125,7 +124,7 @@ class whill_ope(ComWHILL):
             self.start_data_stream(10, 0, i)
             while old_count == self.seq_data_set_0:
                 self.refresh()
-        self.start_data_stream(100)
+        self.start_data_stream(50)
 
     def velocity2joy(self, v, w):
         """速度・角速度入力をジョイスティック入力に変換する関数"""
@@ -145,7 +144,6 @@ class whill_ope(ComWHILL):
 
     def velocity2cmd(self, v, w):
         """速度・角速度入力を実機入力に変換する関数"""
-        d = 0.25 # ホイール間距離/2
         unit = 0.004 # 最小単位 km/h
         front = min(max(v*3.6/unit,-500),1500)
         side = min(max(-w*3.6/unit,-750),750)

--- a/3_dockerfiles_exp/dockerfile.velodyne
+++ b/3_dockerfiles_exp/dockerfile.velodyne
@@ -11,6 +11,7 @@ RUN source /opt/ros/${ROS_DISTRO}/setup.bash \
 && mkdir -p ~/ros2_ws/src\
 &&  cd ~/ros2_ws/src \
 && git clone --depth 1 https://github.com/ros-drivers/velodyne.git \
+&& sed -i "s/^\s*rpm:\s*[0-9.]\+/        rpm: 1200.0/" ~/ros2_ws/src/velodyne/velodyne_driver/config/VLP16-velodyne_driver_node-params.yaml && \
 && . /opt/ros/${ROS_DISTRO}/setup.sh \
 && cd ~/ros2_ws/ \
 && colcon build \

--- a/3_dockerfiles_exp/dockerfile.velodyne
+++ b/3_dockerfiles_exp/dockerfile.velodyne
@@ -5,7 +5,7 @@ FROM ${BASE_IMAGE} as base
 SHELL [ "/bin/bash","-c" ]
 
 RUN apt update\
-&&  apt install libpcap-dev
+&&  apt install -y libpcap-dev
 
 RUN source /opt/ros/${ROS_DISTRO}/setup.bash \
 && mkdir -p ~/ros2_ws/src\

--- a/3_dockerfiles_exp/dockerfile.velodyne
+++ b/3_dockerfiles_exp/dockerfile.velodyne
@@ -4,15 +4,21 @@ FROM ${BASE_IMAGE} as base
 
 SHELL [ "/bin/bash","-c" ]
 
-RUN apt update\
-&&  apt install -y libpcap-dev
+# RUN apt update\
+# &&  apt install -y libpcap-dev
 
-RUN source /opt/ros/${ROS_DISTRO}/setup.bash \
-&& mkdir -p ~/ros2_ws/src\
-&&  cd ~/ros2_ws/src \
-&& git clone --depth 1 https://github.com/ros-drivers/velodyne.git \
-&& sed -i "s/^\s*rpm:\s*[0-9.]\+/        rpm: 1200.0/" ~/ros2_ws/src/velodyne/velodyne_driver/config/VLP16-velodyne_driver_node-params.yaml && \
-&& . /opt/ros/${ROS_DISTRO}/setup.sh \
-&& cd ~/ros2_ws/ \
-&& colcon build \
-&& source /root/ros2_ws/install/setup.bash
+# RUN source /opt/ros/${ROS_DISTRO}/setup.bash \
+# && mkdir -p ~/ros2_ws/src\
+# &&  cd ~/ros2_ws/src \
+# && git clone --depth 1 https://github.com/ros-drivers/velodyne.git \
+# && sed -i "s/^\s*rpm:\s*[0-9.]\+/        rpm: 1200.0/" ~/ros2_ws/src/velodyne/velodyne_driver/config/VLP16-velodyne_driver_node-params.yaml && \
+# && . /opt/ros/${ROS_DISTRO}/setup.sh \
+# && cd ~/ros2_ws/ \
+# && colcon build \
+# && source /root/ros2_ws/install/setup.bash
+
+# velodyne のドライバインストール 
+# 
+RUN mkdir -p ~/ros2_ws/src && cd ~/ros2_ws/src \
+  && apt update \  
+  && apt install -y libpcl-dev libyaml-cpp-dev libpcap-dev libpcap0.8 libpcap0.8-dev ros-${ROS_DISTRO}-velodyne

--- a/3_dockerfiles_exp/dockerfile.whill_exp
+++ b/3_dockerfiles_exp/dockerfile.whill_exp
@@ -5,5 +5,6 @@ FROM ${BASE_IMAGE}
 SHELL [ "/bin/bash","-c" ]
 
 #Install Dependent Packages
-RUN /usr/bin/python3 -m pip install --upgrade pip \
+RUN . /root/.venv/bin/activate \ 
+&& /usr/bin/python3 -m pip install --upgrade pip \
 && /usr/bin/python3 -m pip install whill

--- a/project_launch_exp.sh
+++ b/project_launch_exp.sh
@@ -4,7 +4,7 @@ echo $PROJECT
 echo $ROS_DOMAIN_ID
 
 cd $ACSL_ROS2_DIR/0_host_commands/scripts/
-RMW=cyclonedds dup rtk_gnss ublox_launch rtk_gnss rtk_gnss
+RMW=cyclonedds dup rtk_gnss ublox_launch
 RMW=cyclonedds dup whill_exp
 RMW=cyclonedds dup velodyne run
 RMW=cyclonedds dup rtk_gnss run


### PR DESCRIPTION
## やったこと

* **project_launch_exp.sh**: rtk_gnssのdupする部分の誤植修正
* **1_launcher/launch_velodyne.sh**: case runで配信周期を600→1200rpmに変更
* **2_ros_packages/whill_driver/whill_driver /main.py**: whillの速度指令をJoy入力から直接速度指定に変更
* **2_ros_packages/whill_driver/whill_driver /main.py**: whillの情報リフレッシュレートを100→50msに変更
* **2_ros_packages/whill_driver/whill_driver /main.py**: whillが外部入力指令で動作中にJoy入力を検知すると，マニュアル操作に切り替わる．Joy入力が無信号となった3秒後に再度外部指令を受け付ける．
* **3_dockerfiles_exp/dockerfile.velodyne**: velodyneドライバをソースからbuildするものからapt installのものに変更
* **3_dockerfiles_exp/dockerfile.whill_exp**: 仮想環境を作成し，その中にpip installするように変更

## やらないこと

* なし

## できるようになること（ユーザ目線）

* velodyne点群を0.05sで受信できるようになる
* whillの情報（オドメトリ，Joy入力値等）を0.05sで受信できるようになる
* whillが自律走行中(外部入力受信中)に，搭乗者がJoyスティックを使って割り込み操作可能になる．
* whillが入力速度値に対してより迅速に追従する．

## できなくなること（ユーザ目線）

* Joy入力による速度制御ではなくなるため，今までよりも滑らかな入力を生成する必要がある．

## 動作確認

* 点群のPublish周期が0.05sになった．
* whillの情報が0.05s周期で受信できた．
* 直接速度指令によるwhillの速度制御が可能になった．
* 自律走行中にJoyスティックを動かしてマニュアル走行ができた．操作を終了した3秒後に再度自律走行に切り替わった．

## Concerns and areas to focus on
